### PR TITLE
Parallelization feature for training msj_platform

### DIFF
--- a/launch/robot.launch
+++ b/launch/robot.launch
@@ -12,6 +12,7 @@
     <arg name="x" default="0"/>
     <arg name="y" default="0"/>
     <arg name="z" default="0"/>
+    <arg name="workers" default="1"/>
 
     <param name="robot_name" type="string" value="$(arg robot_name)"  />
     <param name="model_name" type="string" value="$(arg model_name)"  />
@@ -33,6 +34,7 @@
           type="$(arg robot_name)"
           respawn="false"
           output="screen"
+          args="$(arg workers)"
     />
 
     <group if="$(arg gazebo)">

--- a/launch/robot.launch
+++ b/launch/robot.launch
@@ -28,10 +28,6 @@
     <param name="max_force" type="double" value="100000"  />
     <param name="controller" type="int" value="2"  />
     <param name="external_robot_state" type="bool" value="$(arg external_robot_state)"/>
-    <!--<node name="controller_manager"
-          pkg="controller_manager"
-          type="spawner"
-          args="$(arg start_controllers)" />-->
 
     <node name="robot_controller"
           pkg="kindyn"

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -331,12 +331,14 @@ void Robot::init(string urdf_file_path, string viapoints_file_path, vector<strin
         k++;
     }
 
+    /*
     controller_type_sub = nh->subscribe("/controller_type", 100, &Robot::controllerType, this);
     joint_state_sub = nh->subscribe("/joint_states", 100, &Robot::JointState, this);
     floating_base_sub = nh->subscribe("/floating_base", 100, &Robot::FloatingBase, this);
     ik_srv = nh->advertiseService("/ik", &Robot::InverseKinematicsService, this);
     fk_srv = nh->advertiseService("/fk", &Robot::ForwardKinematicsService, this);
     interactive_marker_sub = nh->subscribe("/interactive_markers/feedback",1,&Robot::InteractiveMarkerFeedback, this);
+     */
 }
 
 VectorXd Robot::resolve_function(MatrixXd &A_eq, VectorXd &b_eq, VectorXd &f_min, VectorXd &f_max) {

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -594,7 +594,7 @@ void Robot::update() {
                     }
                     i++;
                 }
-           // }
+            //}
 
         }
         { // joint state publisher

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -7,7 +7,7 @@ Robot::Robot() {
         int argc = 0;
         char **argv = NULL;
         ros::init(argc, argv, "CARDSflow robot", ros::init_options::NoSigintHandler);
-    }
+    } //namespace stuff work it out here for every instance
     nh = ros::NodeHandlePtr(new ros::NodeHandle);
     spinner.reset(new ros::AsyncSpinner(0));
     spinner->start();
@@ -544,7 +544,7 @@ void Robot::update() {
         }
         { // robot target publisher
             // Target is not changing but the robot_state should be published to visualize
-           // if((q_target-q_target_prev).norm()>0.001 || (qd_target-qd_target_prev).norm()>0.001 || first_update) { // only if target changed // Commented out for visualization of the training of the OpenAI gym.
+            //if((q_target-q_target_prev).norm()>0.001 || (qd_target-qd_target_prev).norm()>0.001 || first_update) { // only if target changed // Commented out for visualization of the training of the OpenAI gym.
                 if(first_update)
                     first_update = false;
                 q_target_prev = q_target;
@@ -690,6 +690,7 @@ void Robot::forwardKinematics(double dt) {
             qd[i] = 0;
         }
     }
+
 
     integration_time += dt;
     ROS_INFO_THROTTLE(5, "forward kinematics calculated for %lf s", integration_time);

--- a/src/robots/msj_platform.cpp
+++ b/src/robots/msj_platform.cpp
@@ -286,13 +286,13 @@ int main(int argc, char *argv[]) {
     MsjPlatform **ptr = NULL;
     ptr = new MsjPlatform *[workers];
 
-    for(int id = 1; id < workers+1; id++)
-        ptr[id] = new MsjPlatform(urdf, cardsflow_xml, id, workers);
+    for(int id = 0; id < workers; id++)
+        ptr[id] = new MsjPlatform(urdf, cardsflow_xml, id+1, workers);
 
     ROS_INFO("STARTING ROBOT MAIN LOOP...");
 
     ros::waitForShutdown();
-    for(int id = 1; id < workers+1; id++)
+    for(int id = 0; id < workers; id++)
         delete [] ptr[id];
     delete [] ptr;
 

--- a/src/robots/msj_platform.cpp
+++ b/src/robots/msj_platform.cpp
@@ -51,10 +51,7 @@ public:
             l_offset[i] = l[i];
 
     };
-    ~MsjPlatform(){
-        spinner->stop();
-        nh.reset();
-    }
+
     ///Open AI Gym services
     void initService(int id, int num_workers){
         string gym_step_topic, gym_reset_topic, gym_goal_topic;
@@ -282,13 +279,14 @@ int main(int argc, char *argv[]) {
     int workers = atoi( argv[1]);
     cout << "\nNUMBER OF WORKERS " << workers << endl;
 
-
     vector<boost::shared_ptr<MsjPlatform>> platforms;
     for(int id = 0; id < workers; id++) {
         boost::shared_ptr<MsjPlatform> platform(new MsjPlatform(urdf, cardsflow_xml, id + 1, workers));
         platforms.push_back(platform);
     }
+
     ros::waitForShutdown();
+
 
     ROS_INFO("TERMINATING...");
 

--- a/src/robots/msj_platform.cpp
+++ b/src/robots/msj_platform.cpp
@@ -6,6 +6,7 @@
 #include <roboy_simulation_msgs/GymGoal.h>
 #include <common_utilities/CommonDefinitions.h>
 #include <stdlib.h> /* atoi*/
+#include <limits>
 
 #define NUMBER_OF_MOTORS 8
 #define SPINDLERADIUS 0.00575
@@ -13,6 +14,7 @@
 #define msjEncoderTicksPerMeter(meter) ((meter)*(4096.0)/(2.0*M_PI*SPINDLERADIUS))
 
 using namespace std;
+using namespace Eigen;
 
 class MsjPlatform: public cardsflow::kindyn::Robot{
 public:
@@ -151,7 +153,7 @@ public:
         //ROS_INFO("Gymgoal is called");
         bool not_feasible = true;
         float q0= 0.0,q1= 0.0,q2 = 0.0;
-        srand(static_cast<unsigned >(time(0)));
+        srand(static_cast<unsigned int>(clock()));
         while(not_feasible) {
             q0 = min[0] + static_cast<float> (rand() /(static_cast<float> (RAND_MAX/(max[0]-min[0]))));
             q1 = min[1] + static_cast<float> (rand() /(static_cast<float> (RAND_MAX/(max[1]-min[1]))));
@@ -159,17 +161,65 @@ public:
             if (pnpoly(limits[0], limits[1], q0, q1))
                 not_feasible = false;
         }
+
+        q_target << static_cast<double> (q0), static_cast<double> (q1), static_cast<double> (q2);
+
+        update();
         res.q.push_back(q0);
         res.q.push_back(q1);
         res.q.push_back(q2);
 
+        return true;
+
     }
+
+    ///find the closest limit point when the robot is in infeasible state
+    VectorXd findClosestJointLimit(double q0, double q1, double q3){
+        ROS_INFO("FINDING CLOSEST JOINT LIMIT");
+        VectorXd closestLimit;
+        closestLimit.resize(number_of_dofs);
+        closestLimit.setZero();
+
+        double smallestDistance = numeric_limits<double>::max();
+
+        for(int i=0; i < limits[0].size(); i++){
+            VectorXd jointAngle = Vector2d::Zero(), jointLimits = Vector2d::Zero();
+            jointAngle << q0, q1;
+            jointLimits << limits[0][i] ,limits[1][i];
+            double distance = (jointAngle - jointLimits).norm();
+            if (distance < smallestDistance){
+                smallestDistance = distance;
+                closestLimit[0] = jointLimits[0];
+                closestLimit[1] = jointLimits[1];
+                closestLimit[2] = q3;
+            }
+        }
+        return closestLimit;
+    }
+
+    ///set the given joint angle and veloctiy  for each joint
+    void setJointAngleAndVelocity(VectorXd jointAngles, VectorXd jointVel){
+        for(int i=0; i< number_of_dofs; i++){
+            joint_state[i][1] = jointVel[i];		//Setting velocity to zero send the robot to origin..
+            joint_state[i][0] = jointAngles[i];		//Position of ith joint
+            q[i] = jointAngles[i];
+            qd[i] = jointVel[i];
+        }
+    }
+
+    ///set the gymstep function response
+    void setResponse(VectorXd jointAngles,VectorXd jointVel,roboy_simulation_msgs::GymStep::Response &res){
+        for(int i=0; i< number_of_dofs; i++ ){
+            res.q.push_back(jointAngles[i]);
+            res.qdot.push_back(jointVel[i]);
+        }
+    }
+
 
     bool GymStepService(roboy_simulation_msgs::GymStep::Request &req,
                         roboy_simulation_msgs::GymStep::Response &res){
         
         if(req.set_points.size() != 0){ //If no set_point set then just return observation.
-        	//ROS_INFO("Gymstep is called");
         	update();
 	        for(int i=0; i< number_of_cables; i++){
 	        	//Set the commanded tendon velocity from RL agent to simulation 
@@ -181,19 +231,24 @@ public:
 	        ROS_INFO_STREAM_THROTTLE(5, "Ld = " << Ld[0].format(fmt));
 
 	        write();
-	        //ROS_INFO("Gymstep is done");
 	    }
-        for(int i=0; i< number_of_dofs; i++ ){
-        	res.q.push_back(q[i]);
-        	res.qdot.push_back(qd[i]);
-        }
         if(pnpoly(limits[0],limits[1],q[0],q[1])){
             //task space is feasible
             res.feasible = true;
+            setResponse(q,qd,res);
         }
         else{
             //task space is not feasible
             res.feasible = false;
+            VectorXd closestLimit = findClosestJointLimit(q[0],q[1],q[2]); //Find closest boundary point where we can teleport
+            VectorXd jointVel;                          //We hit the boundary so zero velocity.
+
+            jointVel.resize(number_of_dofs);
+            jointVel.setZero();
+
+            setJointAngleAndVelocity(closestLimit, jointVel);
+            setResponse(closestLimit, jointVel,res );
+
         }
         return true;
     }
@@ -201,24 +256,24 @@ public:
                         roboy_simulation_msgs::GymReset::Response &res){
     	//ROS_INFO("Gymreset is called");      
     	integration_time = 0.0;
-        for(int i=0; i< number_of_dofs; i++){
-	       	//Set the commanded tendon velocity from RL agent to simulation 
-	       	//Set the joint states to arrange the initial condition or reset it. Not the q and qdot
-			joint_state[i][0] = 0.0;		//Velocity of ith joint
-			joint_state[i][1] = 0.0;		//Position of ith joint
-            q[i] = 0.0;
-            qd[i] = 0.0;
-	    }
+
+        VectorXd jointAngle, jointVel;
+        jointAngle.resize(number_of_dofs);
+        jointVel.resize(number_of_dofs);
+
+        jointAngle.setZero();
+        jointVel.setZero();
+
+        setJointAngleAndVelocity(jointAngle, jointVel);
 
 	    for(int i=0; i< number_of_cables; i++){
 	        //Set the commanded tendon velocity from RL agent to simulation 
-	        motor_state[i][0] =0.0; 	//Length of the ith cable
+	        motor_state[i][0] = 0.0; 	//Length of the ith cable
 			motor_state[i][1] = 0.0;	//Velocity of the ith cable
 	    }
 
 	 	update();
 
-        //ROS_INFO_STREAM_THROTTLE(5, "q = \n" << q.format(fmt));
         for(int i=0; i< number_of_dofs; i++ ){
         	res.q.push_back(q[i]);
         	res.qdot.push_back(qd[i]);

--- a/src/robots/msj_platform.cpp
+++ b/src/robots/msj_platform.cpp
@@ -22,11 +22,8 @@ public:
      * @param urdf path to urdf
      * @param cardsflow_xml path to cardsflow xml
      */
-<<<<<<< HEAD
     MsjPlatform(string urdf, string cardsflow_xml, int id , int num_workers){
-=======
-    MsjPlatform(string urdf, string cardsflow_xml){
->>>>>>> deepRoboy-feature
+
         if (!ros::isInitialized()) {
             int argc = 0;
             char **argv = NULL;
@@ -37,12 +34,9 @@ public:
         spinner->start();
         motor_command = nh->advertise<roboy_middleware_msgs::MotorCommand>("/roboy/middleware/MotorCommand",1);
 
-<<<<<<< HEAD
-        initService(id, num_workers);
-=======
-        initServices();
 
->>>>>>> deepRoboy-feature
+        initService(id, num_workers);
+
         readJointLimits();
 
         vector<string> joint_names; // first we retrieve the active joint names from the parameter server
@@ -57,7 +51,6 @@ public:
             l_offset[i] = l[i];
 
     };
-<<<<<<< HEAD
     ~MsjPlatform(){
         spinner->stop();
         nh.reset();
@@ -75,21 +68,11 @@ public:
             gym_reset_topic = "/gym_reset";
             gym_goal_topic = "/gym_goal";
         }
-=======
-    void initServices(){
-        // OpenAI gym services
-        string gym_step_topic = "/gym_step";
-        string gym_reset_topic = "/gym_reset";
-        string gym_goal_topic = "/gym_goal";
->>>>>>> deepRoboy-feature
         gym_step = nh->advertiseService(gym_step_topic, &MsjPlatform::GymStepService,this);
         gym_reset = nh->advertiseService(gym_reset_topic, &MsjPlatform::GymResetService,this);
         gym_goal = nh->advertiseService(gym_goal_topic, &MsjPlatform::GymGoalService,this);
     }
-<<<<<<< HEAD
 
-=======
->>>>>>> deepRoboy-feature
     void readJointLimits(){
         // Get the limits of joints
         string path = ros::package::getPath("robots");
@@ -252,18 +235,11 @@ private:
     bool external_robot_state; /// indicates if we get the robot state externally
     ros::NodeHandlePtr nh; /// ROS nodehandle
     ros::Publisher motor_command; /// motor command publisher
-<<<<<<< HEAD
 
-private:
-    double min[3] = {0,0,-1}, max[3] = {0,0,1};
     ros::ServiceServer gym_step; //OpenAI Gym training environment step function, ros service instance
     ros::ServiceServer gym_reset; //OpenAI Gym training environment reset function, ros service instance
     ros::ServiceServer gym_goal; //OpenAI Gym training environment sets new feasible goal function, ros service instance
-=======
-    ros::ServiceServer gym_step; ///OpenAI Gym training environment step function, ros service instance
-    ros::ServiceServer gym_reset; ///OpenAI Gym training environment reset function, ros service instance
-    ros::ServiceServer gym_goal; ///OpenAI Gym training environment sets new goal function, ros service instance
->>>>>>> deepRoboy-feature
+
     vector<double> limits[3];
     double l_offset[NUMBER_OF_MOTORS];
     boost::shared_ptr <ros::AsyncSpinner> spinner;
@@ -302,8 +278,6 @@ int main(int argc, char *argv[]) {
         return 1;
     }
     ROS_INFO("\nurdf file path: %s\ncardsflow_xml %s", urdf.c_str(), cardsflow_xml.c_str());
-
-    MsjPlatform robot(urdf, cardsflow_xml);
 
     int workers = atoi( argv[1]);
     cout << "\nNUMBER OF WORKERS " << workers << endl;

--- a/src/robots/msj_platform.cpp
+++ b/src/robots/msj_platform.cpp
@@ -282,19 +282,13 @@ int main(int argc, char *argv[]) {
     int workers = atoi( argv[1]);
     cout << "\nNUMBER OF WORKERS " << workers << endl;
 
-    ///Multiple instances of workers are created for parallelized training.
-    MsjPlatform **ptr = NULL;
-    ptr = new MsjPlatform *[workers];
 
-    for(int id = 0; id < workers; id++)
-        ptr[id] = new MsjPlatform(urdf, cardsflow_xml, id+1, workers);
-
-    ROS_INFO("STARTING ROBOT MAIN LOOP...");
-
+    vector<boost::shared_ptr<MsjPlatform>> platforms;
+    for(int id = 0; id < workers; id++) {
+        boost::shared_ptr<MsjPlatform> platform(new MsjPlatform(urdf, cardsflow_xml, id + 1, workers));
+        platforms.push_back(platform);
+    }
     ros::waitForShutdown();
-    for(int id = 0; id < workers; id++)
-        delete [] ptr[id];
-    delete [] ptr;
 
     ROS_INFO("TERMINATING...");
 


### PR DESCRIPTION
- worker number is an argument. `roslaunch kindyn robot.launch robot_name:=msj_platform worker:= (number of workes)` 
- Controllers are deactivated in launch file.
- Due to the deactivation of controller some topics should be inaccessible. The most important being joint target position topics which were being used to visualize the target robot state in rviz. @letrend might help us find another way.
- Multiple instantiation of msj_platfrom will create multiple instances of gym services. They will be prefixed starting from 1 e.g /instance1/gym_step
- Bug fix related not returning boolean service function